### PR TITLE
Remove int from val_color_map

### DIFF
--- a/bgp_visualize_asn.py
+++ b/bgp_visualize_asn.py
@@ -166,10 +166,10 @@ class bgp_visualize(object):
             asn_upstream = asn_visualize(asn=asn).get_asn_ups_and_downs(direction='upstreams')
             asn_downstream = asn_visualize(asn=asn).get_asn_ups_and_downs(direction='downstreams')
             for upstream in asn_upstream:
-                val_color_map[int(upstream)] = self.u_color.upper()
+                val_color_map[upstream] = self.u_color.upper()
 
             for downstream in asn_downstream:
-                val_color_map[int(downstream)] = self.d_color.upper()
+                val_color_map[downstream] = self.d_color.upper()
 
         operators_colors = ['#A525D6',
                             '#009933',


### PR DESCRIPTION
During a test I received a Traceback: ValueError: invalid literal for int() with base 10: 'Level 3 Parent, LLC'
For mitigate this, I removed the int during the conversion when the application try to colorize the upstream and downstream stuffs.